### PR TITLE
locker-support should depend on pyhesiodfs and macathe4na-standard sh…

### DIFF
--- a/ports/net/macathena-locker-support/Portfile
+++ b/ports/net/macathena-locker-support/Portfile
@@ -21,3 +21,6 @@ checksums           rmd160  5199bfdac32445973a028aed15c31a96e3b01919 \
 use_tar             yes
 depends_lib         port:py${python.version}-afs \
                     port:py${python.version}-hesiod
+
+depends_run		port:macathena-machtype \
+                        port:macathena-pyhesiodfs

--- a/ports/net/macathena-standard/Portfile
+++ b/ports/net/macathena-standard/Portfile
@@ -23,5 +23,4 @@ destroot		{
 }
 
 depends_run		port:macathena-moira \
-				port:macathena-machtype \
-				port:macathena-athrun
+				port:macathena-locker-support


### PR DESCRIPTION
…ould install locker-support