### PR TITLE
macathena-{bash,tcsh}-config

### DIFF
--- a/ports/config/macathena-shell-config/Portfile
+++ b/ports/config/macathena-shell-config/Portfile
@@ -1,0 +1,46 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        mit-athena shell-config 1.19
+name                macathena-shell-config
+description         Macathena bash/tcsh configuration
+long_description    Configure bash and tcsh for local shells
+
+checksums           rmd160  09ebbf02848eda0bb56813c867e48e3496939cc1 \
+                    sha256  515d28dc68195d8598d8a81c780e8e54d8362e32cb076ffebb5c34e90fc9550b \
+                    size    5296
+
+depends_run \
+    port:bash \
+    port:debianutils \
+    port:kerberos5 \
+    port:macathena-locker-support \
+    port:macathena-machtype
+
+post-extract {
+    copy ${filespath}/bash.bashrc.macathena ${workpath}/bash.bashrc.macathena
+}
+patch {
+    reinplace "s|@PREFIX@|${prefix}|g; s|@NAME@|${name}|g" ${workpath}/bash.bashrc.macathena
+    reinplace "s|/bin|${prefix}/bin|g" ${worksrcpath}/debian/01-debathena-shell-init
+    reinplace "s|/bin|${prefix}/bin|g" ${worksrcpath}/debian/cshrc.debathena
+}
+
+configure {}
+build {}
+destroot {
+    copy ${workpath}/bash.bashrc.macathena ${destroot}${prefix}/etc/bash.bashrc.macathena
+    file mkdir ${destroot}${prefix}/share/${name}/bashrc.d/
+    copy ${worksrcpath}/debian/01-debathena-shell-init ${worksrcpath}/debian/01-set-athena-user ${destroot}${prefix}/share/${name}/bashrc.d/
+
+    copy ${worksrcpath}/debian/cshrc.debathena ${destroot}${prefix}/etc/csh.cshrc.macathena
+}
+
+post-activate {
+    system "(grep etc/bash.bashrc.macathena /etc/bashrc || echo \"\[ -r \\\"${prefix}/etc/bash.bashrc.macathena\\\" \] && . \\\"${prefix}/etc/bash.bashrc.macathena\\\"\" >> /etc/bashrc) > /dev/null 2>&1"
+    system "(grep etc/bash.bashrc.macathena /etc/zshrc || echo \"\[ -r \\\"${prefix}/etc/bash.bashrc.macathena\\\" \] && . \\\"${prefix}/etc/bash.bashrc.macathena\\\"\" >> /etc/zshrc) > /dev/null 2>&1"
+    # TODO: Update /etc/cshrc
+}
+
+# TODO: Offer +manual_config variant

--- a/ports/config/macathena-shell-config/files/bash.bashrc.macathena
+++ b/ports/config/macathena-shell-config/files/bash.bashrc.macathena
@@ -1,0 +1,13 @@
+# This is the Macathena bashrc configuration, installed by
+# macathena-bash-config.
+MACATHENA_BASHRC_DIR=@PREFIX@/share/@NAME@/bashrc.d
+
+# Enable MacPorts
+export PATH=@PREFIX@/bin:@PREFIX@/sbin:$PATH
+export MANPATH=@PREFIX@/share/man:$PATH
+
+# Source all bash scripts in our bashrc.d directory.
+for i in `run-parts --list "$MACATHENA_BASHRC_DIR"`; do . "$i"; done
+
+# Inform profile.d that bashrc.d has already been sourced.
+macathena_bashrc_sourced=1

--- a/ports/meta/macathena-locker/Portfile
+++ b/ports/meta/macathena-locker/Portfile
@@ -19,18 +19,16 @@ depends_run \
     port:macathena-kerberos-config \
     port:macathena-locker-support \
     port:macathena-machtype \
-    port:macathena-pyhesiodfs
+    port:macathena-pyhesiodfs \
+    port:macathena-shell-config
 
 # Remaining packages from debathena-locker:
 # debathena-afs-config
 # debathena-athrun
 # debathena-attachandrun
-# debathena-bash-config
 # debathena-delete
 # debathena-hesiod-config
-# debathena-machtype
 # debathena-quota
 # debathena-quota-config
-# debathena-tcsh-config
 # debathena-tellme
 # debathena-zephyr-config


### PR DESCRIPTION
This gives `add` to bash, tcsh, and zsh for macathena-locker.